### PR TITLE
Revamp YTD analyses for portfolio and stock reporting

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ def run_example() -> str:
 
     pi = PortfolioInput(
         holdings=holdings,
-        timeframe_label="all time",
+        timeframe_label="YTD",
         portfolio_returns=portfolio_returns,
         benchmark_returns=benchmark_returns,
         market_returns=benchmark_returns.get("SPY"),
@@ -54,16 +54,18 @@ def run_example() -> str:
     return analyze_portfolio(pi, options)
 
 
-def run_from_user_input(positions, timeframe="6m", model: str | None = None, host: str | None = None):
+def run_from_user_input(positions, timeframe="YTD", model: str | None = None, host: str | None = None):
     """
-    positions: list of dicts with either {symbol, weight_pct, avg_buy_price?, bought_at?}
-               or {symbol, weight (0..1), avg_buy_price?, bought_at?}
-    timeframe: e.g. '1m', '3m', '6m', '1y', 'ytd', or 'last 6 months'
+    positions: list of dicts describing the portfolio. Supported keys per entry:
+        {symbol, cut?, weight?, weight_pct?, avg_buy_price?, bought_at?, sector?, name?}
+        "cut" represents the portfolio slice (0..1). Weight/weight_pct remain supported for
+        backward compatibility.
+    timeframe: ignored — the analysis is always executed on a Year-to-Date window.
     """
     holdings: List[Holding] = holdings_from_user_positions(positions)
     pi = PortfolioInput(
         holdings=holdings,
-        timeframe_label=timeframe,
+        timeframe_label="YTD",
         # Leave series empty; auto_fill_series will populate from Yahoo
         portfolio_returns=[],
         benchmark_returns={},

--- a/portfolio_analysis/processing/models.py
+++ b/portfolio_analysis/processing/models.py
@@ -18,7 +18,7 @@ class PortfolioInput:
     holdings: List[Holding]
 
     # Time horizon and cadence
-    timeframe_label: str = "all time"  # e.g., "YTD", "1y", "3m", or "all time"
+    timeframe_label: str = "YTD"  # Always analysed on a YTD window
     periods_per_year: float = 252.0     # daily default
 
     # Performance series (same periodicity)

--- a/shared/fundamentals.py
+++ b/shared/fundamentals.py
@@ -1,8 +1,14 @@
-import os, requests, datetime as _dt
+"""Lightweight fundamentals fetch helpers."""
+
+import os
 from typing import Dict
 
+import requests
 
-def _session():
+
+def _session() -> requests.Session:
+    """Return a preconfigured requests session."""
+
     s = requests.Session()
     s.headers.update({"User-Agent": "hivest-shared/1.0"})
     return s

--- a/shared/llm_client.py
+++ b/shared/llm_client.py
@@ -2,12 +2,15 @@
 - No dependency on netvest; reads environment variables directly.
 - Returns a callable llm(prompt: str) -> str, or None if Ollama isn't available.
 """
+
 from __future__ import annotations
+
 import os
-import time
 import random
+import time
+from typing import Any, Callable, Dict, Optional
+
 import requests
-from typing import Optional, Callable, Any, Dict
 
 
 # Default model updated to llama3:8b (configurable via .env)

--- a/stock_analysis/llm/prompts.py
+++ b/stock_analysis/llm/prompts.py
@@ -1,27 +1,73 @@
 from datetime import datetime
+from typing import Dict
+
 from ..processing.models import StockMetrics
+
+
+def _fmt_fundamentals(items: Dict[str, float]) -> str:
+    if not items:
+        return "none"
+    return ", ".join(f"{k}={v:.2f}" for k, v in items.items())
+
 
 def build_stock_prompt(symbol: str, tf_label: str, m: StockMetrics) -> str:
     dt_now = datetime.now().strftime("%Y-%m-%d %H:%M")
-    perf = f"{tf_label}: cum={m.cum_return*100:.2f}%, vol={m.volatility*100:.2f}%, beta={m.beta_vs_spy:.2f}, maxDD={m.max_drawdown*100:.2f}%."
-    tech = f"RSI14={m.rsi14:.1f}; SMA20={m.sma20:.2f}; SMA50={m.sma50:.2f}; SMA200={m.sma200:.2f}; off_52w_high={m.pct_from_52w_high*100:.2f}%; off_52w_low={m.pct_from_52w_low*100:.2f}%."
-    fund = ", ".join(f"{k}={v:.2f}" for k,v in m.fundamentals.items()) if m.fundamentals else "n/a"
-    news = "\n".join(f"- {it.get('title','')} [source={it.get('source','')}; date={(it.get('publishedAt','') or '')[:10]}]" for it in (m.news_items or [])[:4]) or "none"
+    perf = {
+        "cum_return_pct": f"{m.cum_return*100:.2f}",
+        "volatility_pct": f"{m.volatility*100:.2f}",
+        "beta_vs_spy": f"{m.beta_vs_spy:.2f}",
+        "max_drawdown_pct": f"{m.max_drawdown*100:.2f}",
+    }
+    technicals = {
+        "rsi14": f"{m.rsi14:.1f}",
+        "sma20": f"{m.sma20:.2f}",
+        "sma50": f"{m.sma50:.2f}",
+        "sma200": f"{m.sma200:.2f}",
+        "pct_from_52w_high": f"{m.pct_from_52w_high*100:.2f}",
+        "pct_from_52w_low": f"{m.pct_from_52w_low*100:.2f}",
+    }
+    fundamentals = _fmt_fundamentals(m.fundamentals)
+    news = "\n".join(
+        f"- {it.get('title','')} [source={it.get('source','')}; date={(it.get('publishedAt','') or '')[:10]}]"
+        for it in (m.news_items or [])[:6]
+    ) or "none"
     nxt = m.next_earnings or "none"
 
     instruction = (
-      "Write one cohesive paragraph for a retail investor. "
-      "Start with numeric change (return vs risk/beta), then technical posture, "
-      "then valuation context if present, then upcoming catalysts, then a balanced suggestion (hold/trim/add) with two watch items. "
-      "Plain English. No bullets. Do not invent numbers."
+        "You are an equity research analyst preparing a forward-looking brief.\n\n"
+        "Output format:\n"
+        "📊 Company Snapshot\n"
+        "<Single line: SYMBOL (Company) → concise description including business model, strategic focus, and most recent revenue/earnings trajectory.>\n"
+        "<Optional second line covering scale/capex if relevant.>\n"
+        "\n"
+        "⚖️ Key Advantages\n"
+        "- 3-4 bullets describing competitive positioning, secular demand, balance sheet strength, or execution momentum. Each bullet should lean on provided metrics or news (cite sources by name, e.g., Reuters).\n"
+        "\n"
+        "⚠️ Risks to Watch\n"
+        "- 3 bullets flagging valuation stretch, competitive threats, regulatory overhang, or execution/capex risks.\n"
+        "\n"
+        "🔮 12–18-Month Outlook (what could drive upside/downside)\n"
+        "- 3-4 bullets focusing strictly on upcoming catalysts, adoption curves, margin levers, or macro signposts to monitor.\n"
+        "Include the next earnings checkpoint if available.\n"
+        "\n"
+        "📝 Conclusions & Recommendations\n"
+        "- 2-3 bullets summarising investment stance (accumulate/hold/trim), key execution priorities, and valuation thoughts.\n"
+        "\n"
+        "💡 Bottom line: <one-sentence forward-looking call summarising the thesis and key swing factors>.\n\n"
+        "Rules:\n"
+        "* Stay grounded in the supplied fundamentals, technicals, and news.\n"
+        "* Emphasise how future demand, monetisation, or capacity plans impact the story.\n"
+        "* Never fabricate numbers or dates."
     )
+
     payload = (
-      f"Generated: {dt_now}\n"
-      f"Symbol: {symbol.upper()}\n"
-      f"Performance: {perf}\n"
-      f"Technicals: {tech}\n"
-      f"Fundamentals: {fund}\n"
-      f"NextEarnings: {nxt}\n"
-      f"News:\n{news}\n"
+        f"Generated: {dt_now}\n"
+        f"Symbol: {symbol.upper()}\n"
+        f"Timeframe: {tf_label}\n"
+        f"Performance: {perf}\n"
+        f"Technicals: {technicals}\n"
+        f"Fundamentals: {fundamentals}\n"
+        f"NextEarnings: {nxt}\n"
+        f"News:\n{news}\n"
     )
     return instruction + "\n\n--- DATA ---\n" + payload


### PR DESCRIPTION
## Summary
- enforce a year-to-date analysis window, normalize simplified portfolio inputs, and expose the new scope in helpers
- redesign the portfolio LLM prompt and deterministic fallback to emit the requested sectioned briefing
- refresh the single-stock prompt/fallback toward the forward-looking bullet format and tidy shared utilities

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ca9ab62ebc832fb8fe1d39b5c3287e